### PR TITLE
Move last-result data to its own kv table

### DIFF
--- a/startup-config/last-result-display-hook/mod.nu
+++ b/startup-config/last-result-display-hook/mod.nu
@@ -36,24 +36,24 @@ def "metadata set-from" [metadata?: record] {
 
 export def main [] {{
   tee {
-    let last_result = (metadata access {|meta| do {} ($meta | kv set _meta_tmp) } | stream limit)
-    let capturing = try { if (kv get LAST_RESULT | default true) { true } else { false } } catch { false }
+    let last_result = (metadata access {|meta| do {} ($meta | kv set -t last_result _meta_tmp) } | stream limit)
+    let capturing = try { if (kv get -t last_result LAST_RESULT | default true) { true } else { false } } catch { false }
     if $capturing {
-      try { kv get _3 | kv set _4 }
-      try { kv get _2 | kv set _3 }
-      try { kv get _1 | kv set _2 }
-      try { kv get _  | kv set _1 }
-      try { kv set _ $last_result }
-      try { kv get _meta3 | kv set _meta4 }
-      try { kv get _meta2 | kv set _meta3 }
-      try { kv get _meta | kv set _meta2 }
-      try { kv get _meta_tmp | kv set _meta }
+      try { kv get -t last_result _3 | kv set -t last_result _4 }
+      try { kv get -t last_result _2 | kv set -t last_result _3 }
+      try { kv get -t last_result _1 | kv set -t last_result _2 }
+      try { kv get -t last_result _  | kv set -t last_result _1 }
+      try { kv set -t last_result _ $last_result }
+      try { kv get -t last_result _meta3 | kv set -t last_result _meta4 }
+      try { kv get -t last_result _meta2 | kv set -t last_result _meta3 }
+      try { kv get -t last_result _meta | kv set -t last_result _meta2 }
+      try { kv get -t last_result _meta_tmp | kv set -t last_result _meta }
     }
   }
 }}
 
 export def "_" [n?: int] {
-  kv get $"_($n)" | metadata set-from (kv get $"_meta($n)")
+  kv get -t last_result $"_($n)" | metadata set-from (kv get -t last_result $"_meta($n)")
 }
 
 export-env {


### PR DESCRIPTION
Cleans up the normal `kv list`.  To examine the last-result table (if really needed), use `kv list -t last-result`